### PR TITLE
Remove Shadow Caster NREs

### DIFF
--- a/GameData/SLIPPIST-1/Clouds/shadows.cfg
+++ b/GameData/SLIPPIST-1/Clouds/shadows.cfg
@@ -27,23 +27,4 @@ EVE_SHADOWS{}
 		caster = Delta
 		caster = Echo
 	}
-	OBJECT
-	{
-		body = Golf
-		caster = Bravo
-		caster = Charlie
-		caster = Delta
-		caster = Echo
-		caster = Foxtrot
-	}
-	OBJECT
-	{
-		body = Hotel
-		caster = Bravo
-		caster = Charlie
-		caster = Delta
-		caster = Echo
-		caster = Foxtrot
-		caster = Golf
-	}
 }


### PR DESCRIPTION
Removes the EVE shadow caster configs for 1g & 1h that for some reason are causing crippling ingame exception spam described in the KSP forum at this post:

https://forum.kerbalspaceprogram.com/index.php?/topic/157020-173-seven-worlds-around-slippist-1-v080-update-august-8th-2019/&do=findComment&comment=3650919

NOTE: should also try just removing the most distant casters for 1g & 1h to see if this resolves the 'out of range' condition, such as:
`		caster = Bravo
		caster = Charlie`