### PR TITLE
Only distant casters create trouble

### DIFF
--- a/GameData/Trappist-1 for Principia/trappist_gravity_model_slippist1.cfg
+++ b/GameData/Trappist-1 for Principia/trappist_gravity_model_slippist1.cfg
@@ -455,4 +455,18 @@
     caster = Trappist-1d
     caster = Trappist-1e
   }
+    @OBJECT:HAS[#body[Golf]] {
+    @body = Trappist-1g
+    !caster,* = delete
+    caster = Trappist-1d
+    caster = Trappist-1e
+    caster = Trappist-1f
+  }
+  @OBJECT:HAS[#body[Hotel]] {
+    @body = Trappist-1h
+    !caster,* = delete
+    caster = Trappist-1e
+    caster = Trappist-1f
+    caster = Trappist-1g
+  }
 }


### PR DESCRIPTION
Restored close casters for 1g & 1h.  No sign of the out of range exception with only the distant casters removed.